### PR TITLE
Better filtering when loading entries from file system

### DIFF
--- a/lib/kubernetes/secret.rb
+++ b/lib/kubernetes/secret.rb
@@ -8,7 +8,7 @@ module Kubernetes
 
     def secrets_list
       begin
-        Dir.entries(path) - ['.', '..', '..data']
+        Dir.entries(path) - ['.', '..', '.*', '..*']
       rescue => e
         puts "-----> No secret mounted or not on kubernetes. No secrets injected."
       end

--- a/lib/kubernetes/secret.rb
+++ b/lib/kubernetes/secret.rb
@@ -8,7 +8,7 @@ module Kubernetes
 
     def secrets_list
       begin
-        Dir.entries(path) - ['.', '..']
+        Dir.entries(path) - ['.', '..', '..data']
       rescue => e
         puts "-----> No secret mounted or not on kubernetes. No secrets injected."
       end

--- a/lib/kubernetes/secret.rb
+++ b/lib/kubernetes/secret.rb
@@ -8,7 +8,7 @@ module Kubernetes
 
     def secrets_list
       begin
-        Dir.entries(path) - ['.', '..', '.*', '..*']
+        Dir.entries(path).select { |f| File.file?("#{path}/#{f}") }
       rescue => e
         puts "-----> No secret mounted or not on kubernetes. No secrets injected."
       end


### PR DESCRIPTION
@zacksiri the new COS k8s nodes in GKE were adding a path `..data` that was causing some errors. After some messing around I settled on filtering against anything that wasn't a file.  This cleanly avoids extra paths that can't be loaded into secrets.